### PR TITLE
Drop the unnecessary lodash peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "react-templates loader module for webpack",
   "main": "index.js",
   "peerDependencies": {
-    "react-templates": "^0.3.0",
-    "lodash": "^3.3.0"
+    "react-templates": "^0.3.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
The lodash doesn't seem to be used in the loader itself so it should not be present in the loader's package.json.

It is used in the react-templates package where it is correctly stated as a dependency.
