### PR TITLE
Use loader-utils to parse options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# OSX
+.DS_STORE
+
+# NPM
+node_modules/
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 var reactTemplates = require('react-templates/src/reactTemplates');
 var url = require('url');
-var queryString = require('querystring');
+var loaderUtils = require('loader-utils');
 
 module.exports = function(source) {
-	var options = queryString.parse(url.parse(this.query).query);
+	var options = loaderUtils.parseQuery(this.query);
 	this.cacheable && this.cacheable();
 	return reactTemplates.convertTemplateToReact(source, options);
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var reactTemplates = require('react-templates/src/reactTemplates');
-var url = require('url');
 var loaderUtils = require('loader-utils');
 
 module.exports = function(source) {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "bugs": {
     "url": "https://github.com/AlexanderPavlenko/react-templates-loader/issues"
   },
-  "homepage": "https://github.com/AlexanderPavlenko/react-templates-loader"
+  "homepage": "https://github.com/AlexanderPavlenko/react-templates-loader",
+  "dependencies": {
+    "loader-utils": "^0.2.15"
+  }
 }


### PR DESCRIPTION
Support options through query params (example `webpack-2`):

``` javascript
 {
        test: /\.rt/,
        loader: 'react-templates-loader',
        query: {
          modules: 'es6',
        },
}
```
