### PR TITLE
Fix for allowing rt-include use with Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,15 @@
 var reactTemplates = require('react-templates/src/reactTemplates');
 var loaderUtils = require('loader-utils');
+var fs = require('fs');
+var path = require('path');
 
 module.exports = function(source) {
 	var options = loaderUtils.parseQuery(this.query);
+	options.readFileSync = (fileName) => {
+		const filePath = path.resolve(path.dirname(this.resourcePath), fileName);
+		this.addDependency(filePath);
+		return fs.readFileSync(filePath);
+	}
 	this.cacheable && this.cacheable();
 	return reactTemplates.convertTemplateToReact(source, options);
 };


### PR DESCRIPTION
rt-include is currently not available in webpack because of how the react-templates api generates the readFileSync api, which this loader bypasses.  This fix simply provides the polyfill while allowing hot-reloading of templates based on dependencies.

This fix will allow the use of the rt-include tag for the loader.